### PR TITLE
Do not transform vimeo or youtube url inside anchor tag

### DIFF
--- a/lib/auto_html/vimeo.rb
+++ b/lib/auto_html/vimeo.rb
@@ -16,7 +16,9 @@ module AutoHtml
       text.gsub(vimeo_pattern) do
         vimeo_id = Regexp.last_match(2)
         tag(:div, class: 'video vimeo') do
-          tag(:iframe, iframe_attributes(vimeo_id)) { '' }
+          tag(:div, class: 'responsive-embed') do
+            tag(:iframe, iframe_attributes(vimeo_id)) { '' }
+          end
         end
       end
     end

--- a/lib/auto_html/vimeo.rb
+++ b/lib/auto_html/vimeo.rb
@@ -24,7 +24,7 @@ module AutoHtml
     private
 
     def vimeo_pattern
-      @vimeo_pattern ||= %r{https?://(www.)?vimeo\.com/([A-Za-z0-9._%-]*)((\?|#)\S+)?}
+      @vimeo_pattern ||= %r{(?<!href=["'])https?://(www.)?vimeo\.com/([A-Za-z0-9._%-]*)((\?|#)\S+)?}
     end
 
     def src_url(vimeo_id)

--- a/lib/auto_html/vimeo.rb
+++ b/lib/auto_html/vimeo.rb
@@ -5,18 +5,18 @@ module AutoHtml
   class Vimeo
     include TagHelper
 
-    def initialize(width: 420, height: 315, allow_fullscreen: true)
+    def initialize(width: 420, height: 315, allow_fullscreen: true, lazy: false)
       @width = width
       @height = height
       @allow_fullscreen = allow_fullscreen
+      @lazy = lazy
     end
 
     def call(text)
       text.gsub(vimeo_pattern) do
         vimeo_id = Regexp.last_match(2)
-        src = src_url(vimeo_id)
         tag(:div, class: 'video vimeo') do
-          tag(:iframe, { src: src }.merge(iframe_attributes)) { '' }
+          tag(:iframe, iframe_attributes(vimeo_id)) { '' }
         end
       end
     end
@@ -31,12 +31,19 @@ module AutoHtml
       "//player.vimeo.com/video/#{vimeo_id}"
     end
 
-    def iframe_attributes
+    def iframe_attributes(vimeo_id)
+      src = src_url(vimeo_id)
       {}.tap do |attrs|
         attrs[:width] = @width
         attrs[:height] = @height
         attrs[:frameborder] = 0
-        attrs.merge!(fullscreen_attributes) if @allow_fullscreen
+        attrs.merge!(fullscreen_attributes) if @allow_fullscreen    
+        if @lazy
+          attrs['data-src'] = src
+          attrs[:class] = 'lazyload'
+        else
+          attrs[:src] = src
+        end
       end
     end
 

--- a/lib/auto_html/youtube.rb
+++ b/lib/auto_html/youtube.rb
@@ -17,7 +17,9 @@ module AutoHtml
         if no_href_attr
           youtube_id = Regexp.last_match(5)
           tag(:div, class: 'video youtube') do
-            tag(:iframe, iframe_attributes(youtube_id)) { '' }
+            tag(:div, class: 'responsive-embed') do
+              tag(:iframe, iframe_attributes(youtube_id)) { '' }
+            end
           end
         else
           # No transformation if matches a href attr

--- a/lib/auto_html/youtube.rb
+++ b/lib/auto_html/youtube.rb
@@ -12,9 +12,15 @@ module AutoHtml
 
     def call(text)
       text.gsub(youtube_pattern) do
-        youtube_id = Regexp.last_match(4)
-        tag(:div, class: 'video youtube') do
-          tag(:iframe, iframe_attributes(youtube_id)) { '' }
+        no_href_attr = Regexp.last_match(1).nil?
+        if no_href_attr
+          youtube_id = Regexp.last_match(5)
+          tag(:div, class: 'video youtube') do
+            tag(:iframe, iframe_attributes(youtube_id)) { '' }
+          end
+        else
+          # No transformation if matches a href attr
+          Regexp.last_match(0)
         end
       end
     end
@@ -24,6 +30,7 @@ module AutoHtml
     def youtube_pattern
       @youtube_pattern ||=
         %r{
+          (href=['"])?
           (https?://)?
           (www.)?
           (

--- a/lib/auto_html/youtube.rb
+++ b/lib/auto_html/youtube.rb
@@ -5,9 +5,10 @@ module AutoHtml
   class YouTube
     include TagHelper
 
-    def initialize(width: 420, height: 315)
+    def initialize(width: 420, height: 315, lazy: false)
       @width = width
       @height = height
+      @lazy = lazy
     end
 
     def call(text)
@@ -44,13 +45,20 @@ module AutoHtml
 
     def iframe_attributes(youtube_id)
       src = "//www.youtube.com/embed/#{youtube_id}"
-      {
+      attrs = {
         width: @width,
         height: @height,
-        src: src,
+        'data-src': src,
         frameborder: 0,
         allowfullscreen: 'yes'
       }
+      if @lazy
+        attrs['data-src'] = src
+        attrs[:class] = 'lazyload'
+      else
+        attrs[:src] = src
+      end
+      attrs
     end
   end
 end

--- a/spec/auto_html/vimeo_spec.rb
+++ b/spec/auto_html/vimeo_spec.rb
@@ -31,4 +31,14 @@ RSpec.describe AutoHtml::Vimeo do
     result = filter.call('http://www.vimeo.com/3300155')
     expect(result).to eq '<div class="video vimeo"><iframe src="//player.vimeo.com/video/3300155" width="300" height="250" frameborder="0" webkitallowfullscreen="yes" mozallowfullscreen="yes" allowfullscreen="yes"></iframe></div>'
   end
+
+  it 'does not transform vimeo url inside an anchor tag with double quotes' do
+    result = subject.call('<a href="http://www.vimeo.com/3300155">vimeo</a>')
+    expect(result).to eq '<a href="http://www.vimeo.com/3300155">vimeo</a>'
+  end
+
+  it 'does not transform vimeo url inside an anchor tag with single quotes' do
+    result = subject.call("<a href='http://www.vimeo.com/3300155'>vimeo</a>")
+    expect(result).to eq "<a href='http://www.vimeo.com/3300155'>vimeo</a>"
+  end
 end

--- a/spec/auto_html/youtube_spec.rb
+++ b/spec/auto_html/youtube_spec.rb
@@ -45,4 +45,9 @@ RSpec.describe AutoHtml::YouTube do
     result = subject.call('www.youtube.com/watch?v=t7NdBIA4zJg')
     expect(result).to eq '<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/t7NdBIA4zJg" frameborder="0" allowfullscreen="yes"></iframe></div>'
   end
+
+  it 'does not transform url inside an anchor tag' do
+    result = subject.call('<a href="http://www.youtube.com/watch?v=t7NdBIA4zJg">youtube</a>')
+    expect(result).to eq '<a href="http://www.youtube.com/watch?v=t7NdBIA4zJg">youtube</a>'
+  end
 end


### PR DESCRIPTION
This pull request fixes the vimeo and youtube script to make sure that URLs inside anchor tags are not transformed. Such as this for example:
```
<a href="http://www.vimeo.com/3300155">vimeo</a>
```
I wasn't able to tweak the Youtube regex properly since the `http` is optional, which mesk . So I had to come up with something a bit more convoluted.